### PR TITLE
Fix catalogue URL and add manual CI/CD trigger

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - develop
-      - eucaim-datamodel
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
 jobs:
   build:
     # Necessary after this repository was renamed from samply/lens-web-components to samply/lens

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
     # Build then a new version is tagged
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/src/components/ResultTable.svelte
+++ b/src/components/ResultTable.svelte
@@ -10,7 +10,7 @@
 	let expanded: boolean[] = new Array(1).fill(false);
 	let dataPasser: LensDataPasser;
 	let catalogueLink: string =
-		'https://catalogue.eucaim.cancerimage.eu/menu/main/app-molgenis-app-biobank-explorer-eucaim/#/collection/';
+		'https://catalogue.eucaim.cancerimage.eu/Eucaim/eucaim-ui/#/dataset/';
 
 	const toggleExpand = (index: string) => {
 		expanded[index] = !expanded[index];

--- a/src/services/backend.service.ts
+++ b/src/services/backend.service.ts
@@ -35,7 +35,7 @@ export const requestBackend = (
 
 	const backend = new Spot(
 		new URL(backendUrl),
-		['procanceri', 'chaimeleon', 'incisive'],
+		['procanceri', 'chaimeleon', 'incisive', 'upv-node'],
 		queryId
 	);
 

--- a/src/services/backend.service.ts
+++ b/src/services/backend.service.ts
@@ -28,7 +28,7 @@ export const requestBackend = (
 	    backendUrl = "https://explorer.eucaim.cancerimage.eu/backend/";
 	} else if (import.meta.env.VITE_TARGET_ENVIRONMENT === "staging") {
 		// TODO: Change back to test instance after merge to main
-		backendUrl = 'https://explorer.eucaim.cancerimage.eu/backend/';
+		backendUrl = 'https://explorer-eucaim.grycap.i3m.upv.es/backend/';
 	} else {
 		backendUrl = 'http://localhost:8055';
 	}


### PR DESCRIPTION
Due to an update of the EUCAIM Catalogue, the URL of the data set endpoints changed. This PR fixes this.
To be able to manually trigger the build, the GitHub Workflow recieved a `workflow_dispatch` trigger