### PR TITLE
fix: update lens-catalogue styles to remove button appearance

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -449,3 +449,8 @@ lens-catalogue::part(query-explain-button-icon):hover {
 lens-chart::part(lens-chart-wrapper) {
   display: revert !important;
 }
+
+/* Don't style the lens tree elements as native buttons. I think Tailwind now styles it weirdly*/
+lens-catalogue::part(lens-data-tree-element-name) {
+  appearance: none;
+}


### PR DESCRIPTION
Prevent lens tree elements from being styled as buttons. If the root cause is that Tailwind v4 preflight sets appearance:button in the shadow DOM, this might fix it.